### PR TITLE
Rename DappConnect to Waku Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Project initialization.
 
-[Unreleased]: https://github.com/status-im/dappconnect-sdks/compare/x...HEAD
+[Unreleased]: https://github.com/status-im/wakuconnect-chat-sdk/compare/x...HEAD

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# DappConnect Chat SDK
+# Waku Connect Chat SDK
 
+A ReactJS SDK to easily integrate a decentralized, end-to-end encrypted chat feature to your dApp.
+
+The Waku Connect Chat SDK enables several type of chats:
+
+- 1:1 Encrypted chats
+- Private group chats
+- Spam resistant public chats, powered by Status Communities (an admin needs to run a Status Desktop or Mobile app to moderate)
+
+It also enables user to create their identity by either:
+
+- Using their Web3 wallet, or,
+- Generate an anonymous identity locally.
+
+## Documentation
+
+WIP.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dappconnect-sdks",
+  "name": "@waku/chat-sdk-root",
   "packageManager": "yarn@3.1.0",
   "license": "MIT OR Apache-2.0",
   "scripts": {

--- a/packages/react-chat-example/package.json
+++ b/packages/react-chat-example/package.json
@@ -2,7 +2,7 @@
   "name": "@waku/react-chat-sdk-example",
   "main": "index.js",
   "version": "0.1.0",
-  "repository": "https://github.com/status-im/dappconnect-chat-sdk/",
+  "repository": "https://github.com/status-im/wakuconnect-chat-sdk/",
   "license": "MIT OR Apache-2.0",
   "packageManager": "yarn@3.0.1",
   "scripts": {

--- a/packages/react-chat-example/src/index.html
+++ b/packages/react-chat-example/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0,minimum-scale=1" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <title>DAppconnect chat</title>
+    <title>Waku Connect Chat</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/react-chat-example/src/index.tsx
+++ b/packages/react-chat-example/src/index.tsx
@@ -1,8 +1,4 @@
-import {
-  DappConnectCommunityChat,
-  darkTheme,
-  lightTheme,
-} from "@waku/react-chat-sdk";
+import { CommunityChat, darkTheme, lightTheme } from "@waku/react-chat-sdk";
 import React, { useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
@@ -77,7 +73,7 @@ function DragDiv() {
           }}
         />
         <FloatingDiv className={showChat ? "" : "hide"}>
-          <DappConnectCommunityChat
+          <CommunityChat
             theme={theme ? lightTheme : darkTheme}
             communityKey={process.env.COMMUNITY_KEY ?? ""}
             config={{

--- a/packages/react-chat/package.json
+++ b/packages/react-chat/package.json
@@ -4,7 +4,7 @@
   "module": "dist/esm/src/index.js",
   "types": "dist/esm/src/index.d.ts",
   "version": "0.1.0",
-  "repository": "https://github.com/status-im/dappconnect-chat-sdk/",
+  "repository": "https://github.com/status-im/wakuconnect-chat-sdk/",
   "license": "MIT OR Apache-2.0",
   "packageManager": "yarn@3.0.1",
   "scripts": {

--- a/packages/react-chat/src/components/CommunityChat.tsx
+++ b/packages/react-chat/src/components/CommunityChat.tsx
@@ -17,19 +17,19 @@ import { Theme } from "../styles/themes";
 
 import { Chat } from "./Chat";
 
-interface DappConnectCommunityChatProps {
+interface CommunityChatProps {
   theme: Theme;
   communityKey: string;
   config: ConfigType;
   fetchMetadata?: (url: string) => Promise<Metadata | undefined>;
 }
 
-export function DappConnectCommunityChat({
+export function CommunityChat({
   theme,
   config,
   fetchMetadata,
   communityKey,
-}: DappConnectCommunityChatProps) {
+}: CommunityChatProps) {
   const ref = useRef<HTMLHeadingElement>(null);
   return (
     <ConfigProvider config={config}>

--- a/packages/react-chat/src/components/CommunityChat.tsx
+++ b/packages/react-chat/src/components/CommunityChat.tsx
@@ -15,7 +15,7 @@ import { Metadata } from "../models/Metadata";
 import { GlobalStyle } from "../styles/GlobalStyle";
 import { Theme } from "../styles/themes";
 
-import { Chat } from "./Chat";
+import { CommunityChatRoom } from "./CommunityChatRoom";
 
 interface CommunityChatProps {
   theme: Theme;
@@ -43,7 +43,7 @@ export function CommunityChat({
                   <IdentityProvider>
                     <MessengerProvider communityKey={communityKey}>
                       <ChatStateProvider>
-                        <Chat />
+                        <CommunityChatRoom />
                         <div id="modal-root" />
                       </ChatStateProvider>
                     </MessengerProvider>

--- a/packages/react-chat/src/components/CommunityChatRoom.tsx
+++ b/packages/react-chat/src/components/CommunityChatRoom.tsx
@@ -44,7 +44,7 @@ function Modals() {
   );
 }
 
-export function Chat() {
+export function CommunityChatRoom() {
   const [state] = useChatState();
   const [showMembers, setShowMembers] = useState(false);
   const [editGroup, setEditGroup] = useState(false);

--- a/packages/react-chat/src/components/Form/ChannelMenu.tsx
+++ b/packages/react-chat/src/components/Form/ChannelMenu.tsx
@@ -121,7 +121,7 @@ export const ChannelMenu = ({
             {!channel.isMuted && <NextIcon />}
             <MenuText>
               {(channel.isMuted ? "Unmute" : "Mute") +
-                (channel.type === "group" ? " Group" : " Chat")}
+                (channel.type === "group" ? " Group" : " CommunityChatRoom")}
             </MenuText>
             {!channel.isMuted && showSubmenu && (
               <MuteMenu
@@ -155,7 +155,9 @@ export const ChannelMenu = ({
               <DeleteIcon width={16} height={16} className="red" />
             )}
             <MenuText className="red">
-              {channel.type === "group" ? "Leave Group" : "Delete Chat"}
+              {channel.type === "group"
+                ? "Leave Group"
+                : "Delete CommunityChatRoom"}
             </MenuText>
           </MenuItem>
         )}

--- a/packages/react-chat/src/components/Modals/WalletModal.tsx
+++ b/packages/react-chat/src/components/Modals/WalletModal.tsx
@@ -52,7 +52,7 @@ export function WalletModal() {
               version: "1",
             },
             message: {
-              action: "Status Chat Key",
+              action: "Status CommunityChatRoom Key",
               onlySignOn: dappUrl,
               message:
                 "This signature will be used to decrypt chat communications; check that the 'onlySignOn' property of this message matches the current website address.",

--- a/packages/react-chat/src/groupChatComponents/DappConnectGroupChat.tsx
+++ b/packages/react-chat/src/groupChatComponents/DappConnectGroupChat.tsx
@@ -15,7 +15,7 @@ import { Metadata } from "../models/Metadata";
 import { GlobalStyle } from "../styles/GlobalStyle";
 import { Theme } from "../styles/themes";
 
-import { GroupChat } from "./GroupChat";
+import { GroupChatRoom } from "./GroupChatRoom";
 
 interface DappConnectGroupChatProps {
   theme: Theme;
@@ -41,7 +41,7 @@ export function DappConnectGroupChat({
                   <IdentityProvider>
                     <MessengerProvider communityKey={undefined}>
                       <ChatStateProvider>
-                        <GroupChat />
+                        <GroupChatRoom />
                         <div id="modal-root" />
                       </ChatStateProvider>
                     </MessengerProvider>

--- a/packages/react-chat/src/groupChatComponents/GroupChat.tsx
+++ b/packages/react-chat/src/groupChatComponents/GroupChat.tsx
@@ -23,7 +23,7 @@ interface DappConnectGroupChatProps {
   fetchMetadata?: (url: string) => Promise<Metadata | undefined>;
 }
 
-export function DappConnectGroupChat({
+export function GroupChat({
   theme,
   config,
   fetchMetadata,

--- a/packages/react-chat/src/groupChatComponents/GroupChat.tsx
+++ b/packages/react-chat/src/groupChatComponents/GroupChat.tsx
@@ -17,17 +17,13 @@ import { Theme } from "../styles/themes";
 
 import { GroupChatRoom } from "./GroupChatRoom";
 
-interface DappConnectGroupChatProps {
+interface GroupChatProps {
   theme: Theme;
   config: ConfigType;
   fetchMetadata?: (url: string) => Promise<Metadata | undefined>;
 }
 
-export function GroupChat({
-  theme,
-  config,
-  fetchMetadata,
-}: DappConnectGroupChatProps) {
+export function GroupChat({ theme, config, fetchMetadata }: GroupChatProps) {
   const ref = useRef<HTMLHeadingElement>(null);
   return (
     <ConfigProvider config={config}>

--- a/packages/react-chat/src/groupChatComponents/GroupChatRoom.tsx
+++ b/packages/react-chat/src/groupChatComponents/GroupChatRoom.tsx
@@ -41,7 +41,7 @@ function Modals() {
   );
 }
 
-export function GroupChat() {
+export function GroupChatRoom() {
   const [state] = useChatState();
   const [showMembers, setShowMembers] = useState(false);
   const [editGroup, setEditGroup] = useState(false);

--- a/packages/react-chat/src/index.ts
+++ b/packages/react-chat/src/index.ts
@@ -1,12 +1,6 @@
 import { CommunityChat } from "./components/CommunityChat";
 import { ConfigType } from "./contexts/configProvider";
-import { DappConnectGroupChat } from "./groupChatComponents/DappConnectGroupChat";
+import { GroupChat } from "./groupChatComponents/GroupChat";
 import { darkTheme, lightTheme } from "./styles/themes";
 
-export {
-  CommunityChat,
-  DappConnectGroupChat,
-  lightTheme,
-  darkTheme,
-  ConfigType,
-};
+export { CommunityChat, GroupChat, lightTheme, darkTheme, ConfigType };

--- a/packages/react-chat/src/index.ts
+++ b/packages/react-chat/src/index.ts
@@ -1,10 +1,10 @@
-import { DappConnectCommunityChat } from "./components/DappConnectCommunityChat";
+import { CommunityChat } from "./components/CommunityChat";
 import { ConfigType } from "./contexts/configProvider";
 import { DappConnectGroupChat } from "./groupChatComponents/DappConnectGroupChat";
 import { darkTheme, lightTheme } from "./styles/themes";
 
 export {
-  DappConnectCommunityChat,
+  CommunityChat,
   DappConnectGroupChat,
   lightTheme,
   darkTheme,

--- a/packages/react-group-chat-example/package.json
+++ b/packages/react-group-chat-example/package.json
@@ -2,7 +2,7 @@
   "name": "@waku/react-group-chat-sdk-example",
   "main": "index.js",
   "version": "0.1.0",
-  "repository": "https://github.com/status-im/dappconnect-chat-sdk/",
+  "repository": "https://github.com/status-im/wakuconnect-chat-sdk/",
   "license": "MIT OR Apache-2.0",
   "packageManager": "yarn@3.0.1",
   "scripts": {

--- a/packages/react-group-chat-example/src/index.html
+++ b/packages/react-group-chat-example/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0,minimum-scale=1" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <title>DAppconnect group chat</title>
+    <title>Waku Connect group chat</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/react-group-chat-example/src/index.tsx
+++ b/packages/react-group-chat-example/src/index.tsx
@@ -1,8 +1,4 @@
-import {
-  DappConnectGroupChat,
-  darkTheme,
-  lightTheme,
-} from "@waku/react-chat-sdk";
+import { darkTheme, GroupChat, lightTheme } from "@waku/react-chat-sdk";
 import React, { useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
@@ -77,7 +73,7 @@ function DragDiv() {
           }}
         />
         <FloatingDiv className={showChat ? "" : "hide"}>
-          <DappConnectGroupChat
+          <GroupChat
             theme={theme ? lightTheme : darkTheme}
             config={{
               environment: process.env.ENV ?? "",

--- a/packages/status-communities/package.json
+++ b/packages/status-communities/package.json
@@ -4,7 +4,7 @@
   "module": "dist/esm/src/index.js",
   "types": "dist/esm/src/index.d.ts",
   "version": "0.1.0",
-  "repository": "https://github.com/status-im/dappconnect-chat-sdk/",
+  "repository": "https://github.com/status-im/wakuconnect-chat-sdk/",
   "license": "MIT OR Apache-2.0",
   "packageManager": "yarn@3.1.0",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@waku/chat-sdk-root@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@waku/chat-sdk-root@workspace:."
+  dependencies:
+    npm-run-all: ^4.1.5
+    prettier: ^2.3.2
+    wsrun: ^5.2.4
+  languageName: unknown
+  linkType: soft
+
 "@waku/preview-proxy@workspace:packages/preview-proxy":
   version: 0.0.0-use.local
   resolution: "@waku/preview-proxy@workspace:packages/preview-proxy"
@@ -3340,16 +3350,6 @@ __metadata:
   checksum: 199f9af7e673f9f188525c3102a329d637ff46c52f6385a4427ff5cb17adcb736189150170a7af7c5701d18d7704bdad130273f4aa7e44c6c4f9967e6115dc93
   languageName: node
   linkType: hard
-
-"dappconnect-sdks@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "dappconnect-sdks@workspace:."
-  dependencies:
-    npm-run-all: ^4.1.5
-    prettier: ^2.3.2
-    wsrun: ^5.2.4
-  languageName: unknown
-  linkType: soft
 
 "dashdash@npm:^1.12.0":
   version: 1.14.1


### PR DESCRIPTION
Remove references to `DappConnect` and replace them with Waku Connect.

Instead of renaming the `DappConnectGroupChat` and `DappConnectCommunityChat` I adopted the following terminology:
- `*ChatRoom`: component that contains the chat, member list, channel list (if applicable)
- `*Chat`: Wraps the `*ChatRoom` component with the necessary themes and provider.